### PR TITLE
Fix for #63

### DIFF
--- a/src/calendar/CalendarMonth.jsx
+++ b/src/calendar/CalendarMonth.jsx
@@ -34,7 +34,7 @@ const CalendarMonth = React.createClass({
 
   renderDay(date, i) {
     let {dateComponent: CalendarDate, value, highlightedDate, highlightedRange, hideSelection, enabledRange, ...props} = this.props;
-    let d = moment(date);
+    let d = moment(date).minutes(1);
 
     let isInSelectedRange;
     let isSelectedDate;


### PR DESCRIPTION
Moment’s `range.contains` function take timestamps into account when
computing if a date is within the given range. `CalendarDate` is
creating a date at midnight on the day in question, which will never be
within the starting range. By setting the day’s time to “one minute
past midnight”, this allows the date comparison to behave a bit more
logically.
